### PR TITLE
Add linear momentum task

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(OPENSOT_TASKS_SOURCES src/tasks/Aggregated.cpp
                     src/tasks/velocity/Contact.cpp
                     src/tasks/velocity/CoM.cpp
                     src/tasks/velocity/AngularMomentum.cpp
+                    src/tasks/velocity/LinearMomentum.cpp                    
                     src/tasks/velocity/Manipulability.cpp
                     src/tasks/velocity/MinimizeAcceleration.cpp
                     src/tasks/velocity/MinimumEffort.cpp

--- a/include/OpenSoT/tasks/velocity/LinearMomentum.h
+++ b/include/OpenSoT/tasks/velocity/LinearMomentum.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2017 Walkman
+ * Authors: Enrico Mingo Hoffman, Pouya Mohammadi
+ * email:  enrico.mingo@iit.it, p.mohammadi@tu-bs.de
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU Lesser General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#ifndef __TASKS_VELOCITY_LINEAR_MOMENTUM_H__
+#define __TASKS_VELOCITY_LINEAR_MOMENTUM_H__
+
+#include <OpenSoT/Task.h>
+#include <XBotInterface/ModelInterface.h>
+#include <kdl/frames.hpp>
+#include <Eigen/Dense>
+
+namespace OpenSoT {
+   namespace tasks {
+       namespace velocity {
+
+    #define BASE_LINK_COM "world"
+    #define DISTAL_LINK_COM "CoM"
+
+       /**
+        * @brief The LinearMomentum class implement the tracking of a desired linear momentum:        
+        *
+        *               \f$ \mathbf{A} \Delta \mathbf{q} = \mathbf{h}_d \text{dT}  \f$
+        *
+        * where \f$ \mathbf{h}_d \f$ is the desired linear momentum at the CoM
+        * @note This is basically a copy of Enrico Mingo's AngularMomentum with
+        * one difference that it takes the linear part of centroidal momentum matrix.
+        */
+       class LinearMomentum : public Task < Eigen::MatrixXd, Eigen::VectorXd > {
+       public:
+           typedef boost::shared_ptr<LinearMomentum> Ptr;
+
+       private:
+           XBot::ModelInterface& _robot;
+
+           Eigen::Vector3d _desiredLinearMomentum;
+
+           Eigen::MatrixXd _Momentum;
+
+           void _update(const Eigen::VectorXd& x);
+
+        public:
+           /**
+            * @brief LinearMomentum constructor
+            * @param x joint states
+            * @param robot reference to a model
+            */
+           LinearMomentum(const Eigen::VectorXd& x, XBot::ModelInterface& robot);
+           ~LinearMomentum();
+
+           /**
+            * @brief setReference set a desired linear momentum at CoM
+            * @param desiredLinearMomentum vector 3x1
+            * NOTE: the input desired linear momentum has to be multiplied by \f$ \text{dT} \f$!
+            */
+           void setReference(const Eigen::Vector3d& desiredLinearMomentum);
+           void setReference(const KDL::Vector& desiredLinearMomentum);
+
+           /**
+            * @brief getReference get the desired linear momentum at CoM
+            * @param desiredLinearMomentum vector 3x1
+            */
+           void getReference(Eigen::Vector3d& desiredLinearMomentum) const;
+           void getReference(KDL::Vector& desiredLinearMomentum) const;
+
+           /**
+            * @brief getBaseLink
+            * @return "world"
+            */
+           std::string getBaseLink();
+
+           /**
+            * @brief getDistalLink
+            * @return "CoM"
+            */
+           std::string getDistalLink();
+
+           /**
+            * @brief isLinearMomentum
+            * @param task a pointer to a Task
+            * @return true if the task is LinearMomentum
+            */
+           static bool isLinearMomentum(OpenSoT::Task<Eigen::MatrixXd, Eigen::VectorXd>::TaskPtr task);
+
+           /**
+            * @brief asLinearMomentum
+            * @param task a pointer to a Task
+            * @return a pointer to an LinearMomentum Task
+            */
+           static OpenSoT::tasks::velocity::LinearMomentum::Ptr asLinearMomentum(OpenSoT::Task<Eigen::MatrixXd, Eigen::VectorXd>::TaskPtr task);
+       };
+    }
+   }
+}
+
+#endif

--- a/src/tasks/velocity/LinearMomentum.cpp
+++ b/src/tasks/velocity/LinearMomentum.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2017 Walkman
+ * Author: Enrico Mingo Hoffman, Pouya Mohammadi
+ * email:  enrico.mingo@iit.it, p.mohammadi@tu-bs.de
+ * Permission is granted to copy, distribute, and/or modify this program
+ * under the terms of the GNU Lesser General Public License, version 2 or any
+ * later version published by the Free Software Foundation.
+ *
+ * A copy of the license can be found at
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details
+*/
+
+#include <OpenSoT/tasks/velocity/LinearMomentum.h>
+
+using namespace OpenSoT::tasks::velocity;
+
+LinearMomentum::LinearMomentum(const Eigen::VectorXd& x, XBot::ModelInterface& robot):
+    Task("LinearMomentum", x.size()), _robot(robot)
+{
+    _desiredLinearMomentum.setZero();
+    this->_update(x);
+
+    _W.resize(3,3);
+    _W.setIdentity(3,3);
+
+    _hessianType = HST_SEMIDEF;
+
+    _Momentum.resize(6, _x_size);
+    _A.resize(3, _x_size);
+    _b = _desiredLinearMomentum;
+}
+
+LinearMomentum::~LinearMomentum()
+{
+
+}
+
+void LinearMomentum::_update(const Eigen::VectorXd& x)
+{
+    _robot.getCentroidalMomentumMatrix(_Momentum);
+    _A = _Momentum.block(0,0,3,_x_size);
+    _b = _desiredLinearMomentum;
+}
+
+void LinearMomentum::setReference(const Eigen::Vector3d& desiredLinearMomentum)
+{
+    _desiredLinearMomentum = desiredLinearMomentum;
+}
+
+void LinearMomentum::setReference(const KDL::Vector& desiredLinearMomentum)
+{
+    _desiredLinearMomentum[0] = desiredLinearMomentum[0];
+    _desiredLinearMomentum[1] = desiredLinearMomentum[1];
+    _desiredLinearMomentum[2] = desiredLinearMomentum[2];
+}
+
+void LinearMomentum::getReference(Eigen::Vector3d& desiredLinearMomentum) const
+{
+    desiredLinearMomentum = _desiredLinearMomentum;
+}
+
+void LinearMomentum::getReference(KDL::Vector& desiredLinearMomentum) const
+{
+    desiredLinearMomentum[0] = _desiredLinearMomentum[0];
+    desiredLinearMomentum[1] = _desiredLinearMomentum[1];
+    desiredLinearMomentum[2] = _desiredLinearMomentum[2];
+}
+
+std::string LinearMomentum::getBaseLink()
+{
+    return BASE_LINK_COM;
+}
+
+std::string LinearMomentum::getDistalLink()
+{
+    return DISTAL_LINK_COM;
+}
+
+LinearMomentum::Ptr LinearMomentum::asLinearMomentum(OpenSoT::Task<Eigen::MatrixXd, Eigen::VectorXd>::TaskPtr task)
+{
+    return boost::dynamic_pointer_cast<LinearMomentum>(task);
+}
+
+
+bool LinearMomentum::isLinearMomentum(OpenSoT::Task<Eigen::MatrixXd, Eigen::VectorXd>::TaskPtr task)
+{
+    return (bool)boost::dynamic_pointer_cast<LinearMomentum>(task);
+}


### PR DESCRIPTION
This is basically a copy of AngularMomentum by @EnricoMingo . It simply uses the first three rows of centroidal momentum matrix, that is:

```cpp
void LinearMomentum::_update(const Eigen::VectorXd& x) {
    _robot.getCentroidalMomentumMatrix(_Momentum);
    _A = _Momentum.block(0,0,3,_x_size); //instead of  _A = _Momentum.block(3,0,3,_x_size);
    _b = _desiredLinearMomentum;
}
```

Some test are done and results make sort of sense, but further experiments are needed.